### PR TITLE
Add on header a link to help for translations/localisation

### DIFF
--- a/header.php
+++ b/header.php
@@ -113,6 +113,7 @@
             <a class="dropdown-item text-dark" href="https://blog.freecad.org/jobs"><?php echo _('Jobs and funding'); ?></a>
             <a class="dropdown-item text-dark" href="https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md"><?php echo _('Contribution guidelines'); ?></a>
             <a class="dropdown-item text-dark" href="https://freecad.github.io/DevelopersHandbook/"><?php echo _('Developers handbook'); ?></a>
+            <a class="dropdown-item text-dark" href="https://wiki.freecad.org/Localisation"><?php echo _('Translations'); ?></a>
           </div>
         </li>
 


### PR DESCRIPTION
Hi !
Here is a small update to header.php to include a wiki link for people interested to help in translations/localisation. Adding the link to the wiki as the page has more information about translations overall than directly on Crowdin seems appropriate to me. What do you think ?